### PR TITLE
feat(dril): no repeats + dril emoji trigger

### DIFF
--- a/src/features/ping/dril.ts
+++ b/src/features/ping/dril.ts
@@ -64,7 +64,6 @@ export const TOOTS = [
     "https://twitter.com/dril/status/715139916246552576",
     "https://twitter.com/dril/status/734307632375336960",
     "https://twitter.com/dril/status/760997832237129729",
-    "https://twitter.com/dril/status/764864532720279552",
     "https://twitter.com/dril/status/545926930982502400",
     "https://twitter.com/dril/status/708292373802065921",
     "https://twitter.com/dril/status/545789616738287616",
@@ -90,4 +89,7 @@ export const TOOTS = [
     "https://twitter.com/dril/status/383740993637343232",
     "https://twitter.com/dril/status/504134967946141697",
     "https://twitter.com/dril/status/496077711434330113",
+    "https://twitter.com/dril/status/831805955402776576",
+    "https://twitter.com/dril/status/653978129749426176",
+    "https://twitter.com/dril/status/344941923351527424",
 ]

--- a/src/features/ping/index.ts
+++ b/src/features/ping/index.ts
@@ -31,6 +31,33 @@ const RESPONSES = [
     "pong, cunt",
 ]
 
+let drilTweets: string[] = shuffle(TOOTS.slice(0))
+
+function drilTweet() {
+
+    if (drilTweets.length === 0) {
+        drilTweets = shuffle(TOOTS.slice(0))
+    }
+
+    const tweet = drilTweets.pop()
+    return tweet
+}
+
+function shuffle(a) {
+    let j = 0
+    let x = 0
+    let i = 0
+
+    for (i = a.length - 1; i > 0; i--) {
+        j = Math.floor(Math.random() * (i + 1))
+        x = a[i]
+        a[i] = a[j]
+        a[j] = x
+    }
+
+    return a
+}
+
 export class PingFeature extends Feature {
     public handleMessage(message: Discord.Message): boolean {
         const tokens = this.commandTokens(message)
@@ -53,8 +80,7 @@ export class PingFeature extends Feature {
         // If the message triggers dril content...
         if (joinedMessage === "drilme") {
             // it's good-ass dril content you seek
-            const idx = Math.floor(Math.random() * TOOTS.length)
-            this.replyWith(message, TOOTS[idx])
+            this.replyWith(message, drilTweet())
             return true
         } else if (joinedMessage === "drillme") {
             // ...th-that's lewd

--- a/src/features/ping/index.ts
+++ b/src/features/ping/index.ts
@@ -78,7 +78,7 @@ export class PingFeature extends Feature {
         }
 
         // If the message triggers dril content...
-        if (joinedMessage === "drilme") {
+        if (joinedMessage === "drilme" || joinedMessage === ":dril:") {
             // it's good-ass dril content you seek
             this.replyWith(message, drilTweet())
             return true


### PR DESCRIPTION
- Ensures you'll see every tweet once before resetting the list. (unless the bot server is restarted or whatever)
- Enables a tweet reply to be triggered by a `:dril:` emoji mention to the bot.
- Adds a few more CRUCIAL dril bangers.